### PR TITLE
Use empty objects instead of arrays, fix #333

### DIFF
--- a/src/services/leafletControlHelpers.js
+++ b/src/services/leafletControlHelpers.js
@@ -49,7 +49,7 @@ angular.module('ui-leaflet').factory('leafletControlHelpers', function ($rootSco
         if(defaults.controls.layers && isDefined(defaults.controls.layers.control)) {
 			control = defaults.controls.layers.control.apply(this, [[], [], controlOptions]);
 		} else {
-			control = new L.control.layers([], [], controlOptions);
+			control = new L.control.layers({}, {}, controlOptions);
 		}
 
         return control;


### PR DESCRIPTION
Fix #333
The `L.control.layers` contructor expects two objects, but two arrays were given. This PR fixes a bug appearing when the user extends arrays (e.g. `Array.prototype.whatever`). I replaced the empty arrays `[]` in the constructor with empty objects `{}`.

cc @elesdoar